### PR TITLE
docs: improve repetitive wording in readme intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [📈 Live Status](https://uptime.circuitverse.org): <!--live status--> **🟩 All systems operational**
 
-This repository contains the open-source uptime monitor and status page for [Upptime](https://upptime.js.org), powered by [Upptime](https://github.com/upptime/upptime).
+This repository contains the open-source uptime status page for CircuitVerse, powered by [Upptime](https://github.com/upptime/upptime).
 
 [![Uptime CI](https://github.com/CircuitVerse/upptime/workflows/Uptime%20CI/badge.svg)](https://github.com/CircuitVerse/upptime/actions?query=workflow%3A%22Uptime+CI%22)
 [![Response Time CI](https://github.com/CircuitVerse/upptime/workflows/Response%20Time%20CI/badge.svg)](https://github.com/CircuitVerse/upptime/actions?query=workflow%3A%22Response+Time+CI%22)


### PR DESCRIPTION
Fixes #173

Updated the README intro sentence to remove repetitive wording while keeping the same meaning.

The line now describes this repository as CircuitVerse's uptime status page powered by Upptime.

How to verify: open README.md and check the first descriptive sentence under the status heading.